### PR TITLE
Update zoneset data for new virtual desktops

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -209,11 +209,11 @@ namespace JSONHelpers
         return true;
     }
 
-    void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const std::wstring& uuid)
+    void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const ZoneSetData& data)
     {
-        if (!uuid.empty() && deviceInfoMap.find(deviceId) != deviceInfoMap.end())
+        if (deviceInfoMap.find(deviceId) != deviceInfoMap.end())
         {
-            deviceInfoMap[deviceId].activeZoneSet.uuid = uuid;
+            deviceInfoMap[deviceId].activeZoneSet = data;
         }
     }
 

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -211,9 +211,10 @@ namespace JSONHelpers
 
     void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const ZoneSetData& data)
     {
-        if (deviceInfoMap.find(deviceId) != deviceInfoMap.end())
+        auto it = deviceInfoMap.find(deviceId);
+        if (it != deviceInfoMap.end())
         {
-            deviceInfoMap[deviceId].activeZoneSet = data;
+            it->second.activeZoneSet = data;
         }
     }
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -201,7 +201,7 @@ namespace JSONHelpers
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
         bool SetAppLastZone(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, int zoneIndex);
 
-        void SetActiveZoneSet(const std::wstring& deviceId, const std::wstring& uuid);
+        void SetActiveZoneSet(const std::wstring& deviceId, const ZoneSetData& zoneSet);
 
         void SerializeDeviceInfoToTmpFile(const DeviceInfoJSON& deviceInfo, std::wstring_view tmpFilePath) const;
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -599,7 +599,12 @@ void ZoneWindow::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
         wil::unique_cotaskmem_string zoneSetId;
         if (SUCCEEDED_LOG(StringFromCLSID(m_activeZoneSet->Id(), &zoneSetId)))
         {
-            JSONHelpers::FancyZonesDataInstance().SetActiveZoneSet(m_uniqueId, zoneSetId.get());
+            JSONHelpers::ZoneSetData data{
+                .uuid = zoneSetId.get(),
+                .type = m_activeZoneSet->LayoutType(),
+                .zoneCount = m_activeZoneSet->GetZones().size()
+            };
+            JSONHelpers::FancyZonesDataInstance().SetActiveZoneSet(m_uniqueId, data);
         }
     }
 }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -601,8 +601,7 @@ void ZoneWindow::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
         {
             JSONHelpers::ZoneSetData data{
                 .uuid = zoneSetId.get(),
-                .type = m_activeZoneSet->LayoutType(),
-                .zoneCount = m_activeZoneSet->GetZones().size()
+                .type = m_activeZoneSet->LayoutType()
             };
             JSONHelpers::FancyZonesDataInstance().SetActiveZoneSet(m_uniqueId, data);
         }

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1367,7 +1367,6 @@ namespace FancyZonesUnitTests
         TEST_METHOD(SetActiveZoneSet)
         {
             FancyZonesData data;
-            const std::wstring uuid = L"uuid";
             const std::wstring uniqueId = L"default_device_id";
 
             json::JsonArray devices;
@@ -1376,16 +1375,24 @@ namespace FancyZonesUnitTests
             json.SetNamedValue(L"devices", devices);
             data.ParseDeviceInfos(json);
 
-            data.SetActiveZoneSet(uniqueId, uuid);
+            JSONHelpers::ZoneSetData expectedZoneSetData{
+                .uuid = L"uuid",
+                .type = ZoneSetLayoutType::Focus,
+                .zoneCount = 15
+            };
+
+            data.SetActiveZoneSet(uniqueId, expectedZoneSetData);
 
             auto actual = data.GetDeviceInfoMap().find(uniqueId)->second;
-            Assert::AreEqual(uuid, actual.activeZoneSet.uuid);
+            Assert::AreEqual(expectedZoneSetData.uuid.c_str(), actual.activeZoneSet.uuid.c_str());
+            Assert::IsTrue(expectedZoneSetData.type == actual.activeZoneSet.type);
+            Assert::IsTrue(actual.activeZoneSet.zoneCount.has_value());
+            Assert::AreEqual(expectedZoneSetData.zoneCount.value(), actual.activeZoneSet.zoneCount.value());
         }
 
         TEST_METHOD(SetActiveZoneSetUuidEmpty)
         {
             FancyZonesData data;
-            const std::wstring uuid = L"";
             const std::wstring expected = L"uuid";
             const std::wstring uniqueId = L"default_device_id";
 
@@ -1395,16 +1402,24 @@ namespace FancyZonesUnitTests
             json.SetNamedValue(L"devices", devices);
             data.ParseDeviceInfos(json);
 
-            data.SetActiveZoneSet(uniqueId, uuid);
+            JSONHelpers::ZoneSetData expectedZoneSetData{
+                .uuid = L"",
+                .type = ZoneSetLayoutType::Focus,
+                .zoneCount = 15
+            };
+
+            data.SetActiveZoneSet(uniqueId, expectedZoneSetData);
 
             auto actual = data.GetDeviceInfoMap().find(uniqueId)->second;
-            Assert::AreEqual(expected, actual.activeZoneSet.uuid);
+            Assert::AreEqual(expectedZoneSetData.uuid.c_str(), actual.activeZoneSet.uuid.c_str());
+            Assert::IsTrue(expectedZoneSetData.type == actual.activeZoneSet.type);
+            Assert::IsTrue(actual.activeZoneSet.zoneCount.has_value());
+            Assert::AreEqual(expectedZoneSetData.zoneCount.value(), actual.activeZoneSet.zoneCount.value());
         }
 
         TEST_METHOD(SetActiveZoneSetUniqueIdInvalid)
         {
             FancyZonesData data;
-            const std::wstring uuid = L"new_uuid";
             const std::wstring expected = L"uuid";
             const std::wstring uniqueId = L"id_not_contained_by_device_info_map";
 
@@ -1415,12 +1430,17 @@ namespace FancyZonesUnitTests
             bool parseRes = data.ParseDeviceInfos(json);
             Assert::IsTrue(parseRes);
 
-            data.SetActiveZoneSet(uniqueId, uuid);
+            JSONHelpers::ZoneSetData zoneSetData{
+                .uuid = L"new_uuid",
+                .type = ZoneSetLayoutType::Focus,
+                .zoneCount = 15
+            };
+
+            data.SetActiveZoneSet(uniqueId, zoneSetData);
 
             const auto& deviceInfoMap = data.GetDeviceInfoMap();
             auto actual = deviceInfoMap.find(L"default_device_id")->second;
-            Assert::AreEqual(expected, actual.activeZoneSet.uuid);
-
+            Assert::AreEqual(expected.c_str(), actual.activeZoneSet.uuid.c_str());
             Assert::IsTrue(deviceInfoMap.end() == deviceInfoMap.find(uniqueId), L"new device info should not be added");
         }
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1377,8 +1377,7 @@ namespace FancyZonesUnitTests
 
             JSONHelpers::ZoneSetData expectedZoneSetData{
                 .uuid = L"uuid",
-                .type = ZoneSetLayoutType::Focus,
-                .zoneCount = 15
+                .type = ZoneSetLayoutType::Focus
             };
 
             data.SetActiveZoneSet(uniqueId, expectedZoneSetData);
@@ -1386,8 +1385,6 @@ namespace FancyZonesUnitTests
             auto actual = data.GetDeviceInfoMap().find(uniqueId)->second;
             Assert::AreEqual(expectedZoneSetData.uuid.c_str(), actual.activeZoneSet.uuid.c_str());
             Assert::IsTrue(expectedZoneSetData.type == actual.activeZoneSet.type);
-            Assert::IsTrue(actual.activeZoneSet.zoneCount.has_value());
-            Assert::AreEqual(expectedZoneSetData.zoneCount.value(), actual.activeZoneSet.zoneCount.value());
         }
 
         TEST_METHOD(SetActiveZoneSetUuidEmpty)
@@ -1404,8 +1401,7 @@ namespace FancyZonesUnitTests
 
             JSONHelpers::ZoneSetData expectedZoneSetData{
                 .uuid = L"",
-                .type = ZoneSetLayoutType::Focus,
-                .zoneCount = 15
+                .type = ZoneSetLayoutType::Focus
             };
 
             data.SetActiveZoneSet(uniqueId, expectedZoneSetData);
@@ -1413,8 +1409,6 @@ namespace FancyZonesUnitTests
             auto actual = data.GetDeviceInfoMap().find(uniqueId)->second;
             Assert::AreEqual(expectedZoneSetData.uuid.c_str(), actual.activeZoneSet.uuid.c_str());
             Assert::IsTrue(expectedZoneSetData.type == actual.activeZoneSet.type);
-            Assert::IsTrue(actual.activeZoneSet.zoneCount.has_value());
-            Assert::AreEqual(expectedZoneSetData.zoneCount.value(), actual.activeZoneSet.zoneCount.value());
         }
 
         TEST_METHOD(SetActiveZoneSetUniqueIdInvalid)
@@ -1432,8 +1426,7 @@ namespace FancyZonesUnitTests
 
             JSONHelpers::ZoneSetData zoneSetData{
                 .uuid = L"new_uuid",
-                .type = ZoneSetLayoutType::Focus,
-                .zoneCount = 15
+                .type = ZoneSetLayoutType::Focus
             };
 
             data.SetActiveZoneSet(uniqueId, zoneSetData);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update active zone set with actual data, not just zoneset uuid. New virtual desktop will use the same zoneset as the primary desktop if the primary monitor has a zoneset.